### PR TITLE
Fix GeoDNS routing, deploy cleanup, DNSSEC rebuild handling and health-check sandboxing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /bgp-lock
 /dnsdist-lock
 /dnsdist.conf.tmp
+/dnsdist.conf.tmp.*
 /geoip-subdomain.txt
 /geoip-subdomain-staging.txt
 /ipinfo-token.txt
@@ -10,8 +11,11 @@
 /nginx-lock
 /nginx-tmp
 /pdns.conf.tmp
+/pdns.conf.tmp.*
 /serial.txt
 /serial-staging.txt
 /bird.local.conf
+/bird.local.conf.*
 /venv/
 /zones.tmp
+/zones.tmp.*

--- a/deploy
+++ b/deploy
@@ -2,12 +2,25 @@
 
 set -o errexit -o nounset -o pipefail
 
+pdns_conf_tmp=
+zones_tmp=
+
+cleanup() {
+    if [[ -n $pdns_conf_tmp ]]; then
+        rm -f "$pdns_conf_tmp"
+    fi
+    if [[ -n $zones_tmp ]]; then
+        rm -rf "$zones_tmp"
+    fi
+}
+
 touch lock
 exec {fd}< lock
 if ! flock -n $fd; then
     echo already deploying >&2
     exit 1
 fi
+trap cleanup EXIT
 
 reconfigure=0
 if [[ $# -eq 1 ]]; then
@@ -54,10 +67,12 @@ for server in ${servers[@]}; do
     fi
 
     if (( reconfigure )); then
-        cp pdns.conf pdns.conf.tmp
-        sed -i "s/{{addresses}}/${addresses[$server]}/g;s/{{threads}}/${threads[$server]:-1}/g" pdns.conf.tmp
-        rsync -pcv --chmod=644 --fsync --preallocate pdns.conf.tmp $remote:/etc/powerdns/pdns.conf
-        rm pdns.conf.tmp
+        pdns_conf_tmp=$(mktemp pdns.conf.tmp.XXXXXXXXXX)
+        cp pdns.conf "$pdns_conf_tmp"
+        sed -i "s/{{addresses}}/${addresses[$server]}/g;s/{{threads}}/${threads[$server]:-1}/g" "$pdns_conf_tmp"
+        rsync -pcv --chmod=644 --fsync --preallocate "$pdns_conf_tmp" $remote:/etc/powerdns/pdns.conf
+        rm "$pdns_conf_tmp"
+        pdns_conf_tmp=
         ssh $remote 'id -u geoipupdate &>/dev/null || useradd -r geoipupdate -md /var/lib/GeoIP -s /usr/bin/nologin && chown -R geoipupdate:geoipupdate /var/lib/GeoIP && chmod 755 /var/lib/GeoIP'
         rsync -pcv --chmod=755 --fsync --preallocate ipinfo-update pdns-trigger-health-checks $remote:/usr/local/bin/
         rsync -pcv --chown root:geoipupdate --chmod=F640 --fsync --preallocate ipinfo-token.txt $remote:/etc/ipinfo-token.txt
@@ -66,11 +81,12 @@ for server in ${servers[@]}; do
 
     rsync -pcv --chmod=644 --fsync --preallocate named.conf $remote:/etc/powerdns/named.conf
 
-    rm -rf zones.tmp
-    cp -r zones zones.tmp
-    sed -i "s/{{serial}}/$serial/g;s/{{continent}}/${continents[$server]}/g;s/{{country}}/${countries[$server]}/g;s/{{region}}/${regions[$server]}/g;s/{{us_west}}/${us_west[$server]:-false}/g;s/{{ns}}/$subdomain/g;s/{{geoip_subdomain}}/$geoip_subdomain/g" zones.tmp/*.zone
-    rsync -prcv --chmod=D755,F644 --delete --fsync --preallocate zones.tmp/ $remote:/etc/powerdns/zones/
-    rm -rf zones.tmp
+    zones_tmp=$(mktemp -d zones.tmp.XXXXXXXXXX)
+    cp -r zones/. "$zones_tmp"
+    sed -i "s/{{serial}}/$serial/g;s/{{continent}}/${continents[$server]}/g;s/{{country}}/${countries[$server]}/g;s/{{region}}/${regions[$server]}/g;s/{{us_west}}/${us_west[$server]:-false}/g;s/{{ns}}/$subdomain/g;s/{{geoip_subdomain}}/$geoip_subdomain/g" "$zones_tmp"/*.zone
+    rsync -prcv --chmod=D755,F644 --delete --fsync --preallocate "$zones_tmp"/ $remote:/etc/powerdns/zones/
+    rm -rf "$zones_tmp"
+    zones_tmp=
 
     if (( reconfigure )); then
         ssh $remote 'sleep 5 &&

--- a/deploy-bgp
+++ b/deploy-bgp
@@ -7,12 +7,21 @@ shopt -s expand_aliases
 
 alias rsync='rsync --fsync --preallocate'
 
+bird_local_conf=
+
+cleanup() {
+    if [[ -n $bird_local_conf ]]; then
+        rm -f "$bird_local_conf"
+    fi
+}
+
 touch bgp-lock
 exec {fd}< bgp-lock
 if ! flock -n $fd; then
     echo already deploying >&2
     exit 1
 fi
+trap cleanup EXIT
 
 for server in ${servers[@]}; do
     echo $server
@@ -28,10 +37,12 @@ for server in ${servers[@]}; do
     ssh $remote 'id -u bird &>/dev/null || useradd -r bird -d / -s /usr/bin/nologin'
     rsync -rpcv --chmod=D755,F644 systemd/system/bird.service.d $remote:/etc/systemd/system/
     rsync -pcv --chmod=644 bird.$subdomain.conf $remote:/etc/bird.conf
-    cp bird.$server.conf bird.local.conf
-    sed -i "s/{{bgp_password}}/${bgp_password[$server]}/g" bird.local.conf
-    rsync -pcv --chmod=644 bird.local.conf $remote:/etc/bird.local.conf
-    rm bird.local.conf
+    bird_local_conf=$(mktemp bird.local.conf.XXXXXXXXXX)
+    cp bird.$server.conf "$bird_local_conf"
+    sed -i "s/{{bgp_password}}/${bgp_password[$server]}/g" "$bird_local_conf"
+    rsync -pcv --chmod=644 "$bird_local_conf" $remote:/etc/bird.local.conf
+    rm "$bird_local_conf"
+    bird_local_conf=
 
     echo
 done

--- a/deploy-dnsdist
+++ b/deploy-dnsdist
@@ -2,12 +2,21 @@
 
 set -o errexit -o nounset -o pipefail
 
+dnsdist_conf_tmp=
+
+cleanup() {
+    if [[ -n $dnsdist_conf_tmp ]]; then
+        rm -f "$dnsdist_conf_tmp"
+    fi
+}
+
 touch dnsdist-lock
 exec {fd}< dnsdist-lock
 if ! flock -n $fd; then
     echo already deploying >&2
     exit 1
 fi
+trap cleanup EXIT
 
 . servers.sh
 
@@ -22,10 +31,12 @@ for server in ${servers[@]}; do
         subdomain=ns2
     fi
 
-    cp dnsdist.conf dnsdist.conf.tmp
-    sed -i "s/{{subdomain}}/$subdomain/g;s/{{threads}}/${threads[$server]:-1}/g" dnsdist.conf.tmp
-    rsync -pcv --chmod=F644 --fsync --preallocate dnsdist.conf.tmp $remote:/etc/dnsdist.conf
-    rm dnsdist.conf.tmp
+    dnsdist_conf_tmp=$(mktemp dnsdist.conf.tmp.XXXXXXXXXX)
+    cp dnsdist.conf "$dnsdist_conf_tmp"
+    sed -i "s/{{subdomain}}/$subdomain/g;s/{{threads}}/${threads[$server]:-1}/g" "$dnsdist_conf_tmp"
+    rsync -pcv --chmod=F644 --fsync --preallocate "$dnsdist_conf_tmp" $remote:/etc/dnsdist.conf
+    rm "$dnsdist_conf_tmp"
+    dnsdist_conf_tmp=
 
     ssh $remote 'usermod -aG tls dnsdist &&
 mkdir -pm750 /etc/dnsdist.conf.d &&


### PR DESCRIPTION
- The GeoDNS Lua templates contain two data issues. Tennessee is included in both the Dallas and Miami region sets, but the Dallas branch is evaluated first, so the Miami entry is unreachable. This PR removes Tennessee from the Dallas set so it routes through the intended Miami path. The IPv6 Lua templates also treat Amsterdam as if it has the same IPv6 address as Frankfurt even though Amsterdam does not currently have a real AAAA record in the zone data. This PR removes Amsterdam from the IPv6 candidate and fallback lists so IPv6 clients are not sent to a mislabeled Frankfurt endpoint.

- The deploy scripts only clean up temporary files on the success path. In particular, a failed deploy-bgp run can leave a generated config containing the cleartext BGP password in the repo working directory. This PR adds exit cleanup for generated temp files, switches those temp files and directories to process-local `mktemp` paths, and adds a lock to deploy-bgp so concurrent runs do not interfere with each other.

- The DNSSEC setup script currently rebuilds the bind DNSSEC database while PowerDNS may still be serving. This creates a window where the server can expose a missing or partially rebuilt DNSSEC database. This PR changes the flow to stop `pdns`, back up the existing database, rebuild and import keys, restore the previous database on failure, and keep rollback protection in place until `pdns` starts successfully.

- The pdns-trigger-health-checks systemd unit currently runs with essentially no sandboxing even though the command only needs to perform a loopback DNS query. This PR adds the same style of systemd hardening already used for other low-privilege maintenance services.

Each commit in this PR stands on its own and can be cherry-picked independently.